### PR TITLE
Fix timer bug issue

### DIFF
--- a/app/src/main/java/com/fridayhouse/snoozz/activities/CustomActivity.kt
+++ b/app/src/main/java/com/fridayhouse/snoozz/activities/CustomActivity.kt
@@ -124,6 +124,10 @@ class CustomActivity : AppCompatActivity() {
                 binding.icAtomAnim.resumeAnimation()
             } else togglePlayPauseButton(false) //binding.actionButtonCustomActivityStopPlay.visibility = View.INVISIBLE
             playerService?.playerChangeListener = playerChangeListener
+
+            // Call updateTimerButtonState once service in connected to update UI
+            updateTimerButtonState()
+
             window.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
         }
     }

--- a/app/src/main/java/com/fridayhouse/snoozz/activities/CustomActivity.kt
+++ b/app/src/main/java/com/fridayhouse/snoozz/activities/CustomActivity.kt
@@ -125,7 +125,7 @@ class CustomActivity : AppCompatActivity() {
             } else togglePlayPauseButton(false) //binding.actionButtonCustomActivityStopPlay.visibility = View.INVISIBLE
             playerService?.playerChangeListener = playerChangeListener
 
-            // Call updateTimerButtonState once service in connected to update UI
+            // Call updateTimerButtonState once service is connected to update UI
             updateTimerButtonState()
 
             window.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)


### PR DESCRIPTION
Fix for [Issue ](https://github.com/th3kumar/Snoozz-Sleeping-Buddy/issues/11)

## Root cause  
- When we navigate from `CustomActivity` to another activity and then come back, `playerService` is null in `onCreate` hence setting the state of timer button incorrectly.

## Fix 
- Set state of timer button once service is connected and hence `playerService` is set.

## Recording 

### Before
[untitled-before.webm](https://github.com/th3kumar/Snoozz-Sleeping-Buddy/assets/58297494/3f3c44b4-00a6-4698-84f5-a032bc3e1b3c)

### After 
[untitled.webm](https://github.com/th3kumar/Snoozz-Sleeping-Buddy/assets/58297494/fa557dca-fa1d-47bf-801c-0411207811b1)

